### PR TITLE
feat: css modules using default export configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,37 @@ Add plugin to `tsconfig.json`:
   ]
 }
 ```
+
+## Css modules with default exports
+
+In case when you are importing css modules as default export:
+
+```ts
+import styles from 'some.css'
+```
+
+ add confifuration parameter in `tsconfig.json` file:
+
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [ { 
+        "name": "css-module-types",
+        "defaultExport": true
+    } ],
+    ...
+  }
+}
+```
+
+## Visual Studio Code integration:
+
+1. install `typescript` and this package localy in project: `npm i typescript css-module-types --save-dev`
+
+2. specify `"typescript.tsdk": "./node_modules/typescript/lib"` in `.vccode/settings.json`
+
+3. switch typescript compiler to workspace version of typescript
+
+4. restart VSCode.
+

--- a/index.ts
+++ b/index.ts
@@ -18,9 +18,18 @@ export = function init({ typescript: ts }: { typescript: typeof ts_module }) {
 
     function getDtsSnapshot(scriptSnapshot: ts.IScriptSnapshot) {
       const css = scriptSnapshot.getText(0, scriptSnapshot.getLength());
-      const dts = Object.keys(extractICSS(processor.process(css).root).icssExports)
+
+      const keys = Object.keys(extractICSS(processor.process(css).root).icssExports);
+      let dts:string;
+
+      if (info.config.defaultExport) {
+        dts = `declare const styles: { ${keys.map(exportName => `${exportName}: string;`).join('')} }; export default styles;`;
+      } else {
+        dts = keys
           .map(exportName => `export const ${exportName}: string;`)
           .join('');
+      }
+
       return ts.ScriptSnapshot.fromString(dts);
     }
 


### PR DESCRIPTION
[fuse-box](https://fuse-box.org/) CSSModulesPlugin uses default export when generating css modules javascript code so i add tsConfig.json configuration parameter "defaultExport" that if set to true will switch generated d.ts files from

```ts
export const red: string;
export const green: string;
```
to

```ts
declare const styles: { 
  red: string;
  green: string;
};
export default styles;
```

so they can be imported like:

```ts
import styles from "./style.css"
```

PS: non-english speaker so readme.md may contain wierd words :)